### PR TITLE
Fix missing conversions in LatLonV.intersection

### DIFF
--- a/latlon-vectors.js
+++ b/latlon-vectors.js
@@ -221,16 +221,12 @@ LatLonV.prototype.destinationPoint = function(bearing, distance) {
  */
 LatLonV.intersection = function(path1start, path1brngEnd, path2start, path2brngEnd) {
     if (path1brngEnd instanceof LatLonV) {       // path 1 defined by endpoint
-        var p1s = path1start.toVector();
-        var p1e = path1brngEnd.toVector();
-        var c1 = p1s.cross(p1e);
+        var c1 = path1start.toVector().cross(path1brngEnd.toVector());
     } else {                                     // path 1 defined by initial bearing
         var c1 = path1start.greatCircle(path1brngEnd);
     }
     if (path2brngEnd instanceof LatLonV) {       // path 2 defined by endpoint
-        var p2s = path2start.toVector();
-        var p2e = path2brngEnd.toVector();
-        var c2 = p2s.cross(p2e);
+        var c2 = path2start.toVector().cross(path2brngEnd.toVector());
     } else {                                     // path 2 defined by initial bearing
         var c2 = path2start.greatCircle(path2brngEnd);
     }


### PR DESCRIPTION
There is no cross function in the `LatLonV` class, so the input parameters
should be converted to `Vector3d` first when calculating intersection with
four points.
