### PR TITLE
LatLonV.meanOf should return LatLonV

### DIFF
--- a/latlon-vectors.js
+++ b/latlon-vectors.js
@@ -334,7 +334,7 @@ LatLonV.meanOf = function(points) {
     }
 
     // m is now geographic mean
-    return m.unit();
+    return m.unit().toLatLon();
 }
 
 


### PR DESCRIPTION
`LatLonV.meanOf` should return `LatLonV` instead of `Vector3d`.
