### PR TITLE
Added overloading to first constructor argument

### DIFF
--- a/latlon-ellipsoid.js
+++ b/latlon-ellipsoid.js
@@ -37,6 +37,14 @@ if (typeof module!='undefined' && module.exports) var Geo = require('./geo.js');
  *     var p1 = new LatLonE(51.4778, -0.0016, LatLonE.datum.WGS84);
  */
 function LatLonE(lat, lon, datum, height) {
+    // allow instantiation with a "LatLonE-similar" object as first argument
+    if (typeof lat == 'object') {
+      lat = lat.lat
+      lon = lat.lon
+      height = lat.height
+      radius = lat.radius
+    }
+
     // allow instantiation without 'new'
     if (!(this instanceof LatLonE)) return new LatLonE(lat, lon, datum, height);
 

--- a/latlon-ellipsoid.js
+++ b/latlon-ellipsoid.js
@@ -39,10 +39,10 @@ if (typeof module!='undefined' && module.exports) var Geo = require('./geo.js');
 function LatLonE(lat, lon, datum, height) {
     // allow instantiation with a "LatLonE-similar" object as first argument
     if (typeof lat == 'object') {
-      lat = lat.lat
       lon = lat.lon
       height = lat.height
       radius = lat.radius
+      lat = lat.lat
     }
 
     // allow instantiation without 'new'

--- a/latlon-vectors.js
+++ b/latlon-vectors.js
@@ -34,10 +34,10 @@ if (typeof module!='undefined' && module.exports) var Geo = require('./geo.js');
 function LatLonV(lat, lon, height, radius) {
     // allow instantiation with a "LatLonV-similar" object as first argument
     if (typeof lat == 'object') {
-      lat = lat.lat
       lon = lat.lon
       height = lat.height
       radius = lat.radius
+      lat = lat.lat
     }
 
     // allow instantiation without 'new'

--- a/latlon-vectors.js
+++ b/latlon-vectors.js
@@ -32,6 +32,14 @@ if (typeof module!='undefined' && module.exports) var Geo = require('./geo.js');
  *   var p1 = new LatLonV(52.205, 0.119);
  */
 function LatLonV(lat, lon, height, radius) {
+    // allow instantiation with a "LatLonV-similar" object as first argument
+    if (typeof lat == 'object') {
+      lat = lat.lat
+      lon = lat.lon
+      height = lat.height
+      radius = lat.radius
+    }
+
     // allow instantiation without 'new'
     if (!(this instanceof LatLonV)) return new LatLonV(lat, lon, height, radius);
 

--- a/latlon.js
+++ b/latlon.js
@@ -24,6 +24,14 @@ if (typeof module!='undefined' && module.exports) var Geo = require('./geo'); //
  *     var p1 = new LatLon(52.205, 0.119);
  */
 function LatLon(lat, lon, height, radius) {
+    // allow instantiation with a "LatLon-similar" object as first argument
+    if (typeof lat == 'object') {
+      lat = lat.lat
+      lon = lat.lon
+      height = lat.height
+      radius = lat.radius
+    }
+
     // allow instantiation without 'new'
     if (!(this instanceof LatLon)) return new LatLon(lat, lon, height, radius);
 

--- a/latlon.js
+++ b/latlon.js
@@ -26,10 +26,10 @@ if (typeof module!='undefined' && module.exports) var Geo = require('./geo'); //
 function LatLon(lat, lon, height, radius) {
     // allow instantiation with a "LatLon-similar" object as first argument
     if (typeof lat == 'object') {
-      lat = lat.lat
       lon = lat.lon
       height = lat.height
       radius = lat.radius
+      lat = lat.lat
     }
 
     // allow instantiation without 'new'


### PR DESCRIPTION
By this, you can easily create LatLon-Object out of similar ones, e.g. as returned from `GeoHash.decode`:

```js
var latLon = new LatLon(GeoHash.decode("silly"));
```