### PR TITLE
fix doc typo: `Dms.parse()` to `Dms.parseDMS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ More information at www.movable-type.co.uk/scripts/latlong-gridref.html.
 Conversions between decimal degrees and (sexagesimal) degrees-minutes-seconds (and compass points).
 
 * *Methods*
-    * `Dms.parse(dmsStr)`
+    * `Dms.parseDMS(dmsStr)`
         - Parse string representing degrees/minutes/seconds into numeric degrees
     * `Dms.toDms(degrees[, format[, decimals]])`
         - Convert decimal degrees to deg/min/sec format


### PR DESCRIPTION
this is a typo, no?  doesn't look like there's a `parse` method on the Dms class: see [the file](https://github.com/chrisveness/geodesy/blob/master/dms.js#L44-L75).

