### PR TITLE
Properly handle squares that occupy two latitude bands

### DIFF
--- a/mgrs.js
+++ b/mgrs.js
@@ -100,7 +100,7 @@ Utm.prototype.toMgrs = function() {
 
     // columns in zone 1 are A-H, zone 2 J-R, zone 3 S-Z, then repeating every 3rd zone
     var col = Math.floor(this.easting / 100e3);
-    var e100k = Mgrs.e100kLetters[(zone-1)%3].charAt(col-1); // TODO: why col-1?
+    var e100k = Mgrs.e100kLetters[(zone-1)%3].charAt(col-1); // col-1 since 1*100e3 -> A (index 0), 2*100e3 -> B (index 1), etc.
 
     // rows in even zones are A-V, in odd zones are F-E
     var row = Math.floor(this.northing / 100e3) % 20;
@@ -138,7 +138,7 @@ Mgrs.prototype.toUtm = function() {
     var hemisphere = band>='N' ? 'N' : 'S';
 
     // get easting specified by e100k
-    var col = Mgrs.e100kLetters[(zone-1)%3].indexOf(e100k) + 1; // TODO: why +1?
+    var col = Mgrs.e100kLetters[(zone-1)%3].indexOf(e100k) + 1; // index+1 since A (index 0) -> 1*100e3, B (index 1) -> 2*100e3, etc.
     var e100kNum = col * 100e3; // e100k in metres
 
     // get northing specified by n100k
@@ -148,9 +148,11 @@ Mgrs.prototype.toUtm = function() {
     // get latitude of (bottom of) band
     var latBand = (Mgrs.latBands.indexOf(band)-10)*8;
 
+    // northing of bottom of band, extended to include entirety of bottommost 100km square
+    // (100km square boundaries are aligned with 100km UTM northing intervals)
+    var nBand = Math.floor(new LatLon(latBand, 0).toUtm().northing/100e3)*100e3;
     // 100km grid square row letters repeat every 2,000km north; add enough 2,000km blocks to get
     // into required band
-    var nBand = new LatLon(latBand, 0).toUtm().northing; // northing of bottom of band
     var n2M = 0; // northing of 2,000km block
     while (n2M + n100kNum + northing < nBand) n2M += 2000e3;
 

--- a/test/utm-mgrs-tests.js
+++ b/test/utm-mgrs-tests.js
@@ -59,11 +59,13 @@ describe('utm/mgrs', function() {
     test('MGRS->UTM white house',      function() { Mgrs.parse('18S UJ 23394 07395').toUtm().toString().should.equal('18 N 323394 4307395'); });
     test('MGRS->UTM rio christ',       function() { Mgrs.parse('23K PQ 83466 60687').toUtm().toString().should.equal('23 S 683466 7460687'); });
     test('MGRS->UTM bergen',           function() { Mgrs.parse('32V KN 97508 00645').toUtm().toString().should.equal('32 N 297508 6700645'); });
+    test('MGRS->UTM 01PET0000068935',  function() { Mgrs.parse('01P ET 00000 68935').toUtm().toString().should.equal('1 N 500000 1768935'); });
+    test('MGRS->UTM 01QET0000068935',  function() { Mgrs.parse('01Q ET 00000 68935').toUtm().toString().should.equal('1 N 500000 1768935'); });
 
     // varying resolution
-    test('MGRS 4-digit',         function() { Mgrs.parse('12S TC 52 86').toUtm().toString().should.equal('12 N 252000 3786000'); });
-    test('MGRS 10-digit',         function() { Mgrs.parse('12S TC 52000 86000').toUtm().toString().should.equal('12 N 252000 3786000'); });
-    test('MGRS 10-digit+decimals',         function() { Mgrs.parse('12S TC 52000.123 86000.123').toUtm().toString(3).should.equal('12 N 252000.123 3786000.123'); });
+    test('MGRS 4-digit',               function() { Mgrs.parse('12S TC 52 86').toUtm().toString().should.equal('12 N 252000 3786000'); });
+    test('MGRS 10-digit',              function() { Mgrs.parse('12S TC 52000 86000').toUtm().toString().should.equal('12 N 252000 3786000'); });
+    test('MGRS 10-digit+decimals',     function() { Mgrs.parse('12S TC 52000.123 86000.123').toUtm().toString(3).should.equal('12 N 252000.123 3786000.123'); });
 
     /* http://www.ibm.com/developerworks/library/j-coordconvert/
      ( 0.0000    0.0000  )     "31 N 166021 0"


### PR DESCRIPTION
Per GEOTRANS, square references should "be considered valid if any part of the square which they denote lies within the latitude zone specified by the third letter of the string."

See: https://en.wikipedia.org/wiki/Military_grid_reference_system#Squares_that_cross_a_latitude_band_boundary