### PR TITLE
Adds rollup configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+dist

--- a/latlon-ellipsoidal.js
+++ b/latlon-ellipsoidal.js
@@ -35,7 +35,7 @@ if (typeof module!='undefined' && module.exports) var Dms = require('./dms.js');
  * @example
  *     var p1 = new LatLon(51.4778, -0.0016, LatLon.datum.WGS84);
  */
-function LatLon(lat, lon, datum) {
+var LatLon = function(lat, lon, datum) {
     // allow instantiation without 'new'
     if (!(this instanceof LatLon)) return new LatLon(lat, lon, datum);
 

--- a/latlon-spherical.js
+++ b/latlon-spherical.js
@@ -27,7 +27,7 @@ if (typeof module!='undefined' && module.exports) var Dms = require('./dms.js');
  * @example
  *     var p1 = new LatLon(52.205, 0.119);
  */
-function LatLon(lat, lon) {
+var LatLon = function(lat, lon) {
     // allow instantiation without 'new'
     if (!(this instanceof LatLon)) return new LatLon(lat, lon);
 

--- a/latlon-vectors.js
+++ b/latlon-vectors.js
@@ -35,7 +35,7 @@ if (typeof module!='undefined' && module.exports) var Dms = require('./dms.js');
  * @example
  *   var p1 = new LatLon(52.205, 0.119);
  */
-function LatLon(lat, lon) {
+var LatLon = function(lat, lon) {
     // allow instantiation without 'new'
     if (!(this instanceof LatLon)) return new LatLon(lat, lon);
 

--- a/osgridref.js
+++ b/osgridref.js
@@ -36,7 +36,7 @@ if (typeof module!='undefined' && module.exports) var LatLon = require('./latlon
  * @example
  *   var grid = new OsGridRef(651409, 313177);
  */
-function OsGridRef(easting, northing) {
+var OsGridRef = function(easting, northing) {
     // allow instantiation without 'new'
     if (!(this instanceof OsGridRef)) return new OsGridRef(easting, northing);
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "version": "1.1.3",
     "license": "MIT",
     "main": "npm.js",
+    "module": "geodesy",
     "bugs": "https://github.com/chrisveness/geodesy/issues",
     "scripts": {
+        "dist": "rollup -c",
         "test": "mocha test/*.js",
         "lint": "eslint ."
     },
@@ -19,7 +21,10 @@
         "jsdoc": "^3.5.5",
         "mocha": "^5.0.1",
         "npm-check": "^5.5.2",
-        "npm-check-updates": "^2.14.1"
+        "npm-check-updates": "^2.14.1",
+        "rollup": "^0.64.0",
+        "rollup-plugin-commonjs": "^9.1.0",
+        "rollup-plugin-node-resolve": "^3.0.0"
     },
     "eslintConfig": {
         "env": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,19 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+
+export default [
+	// browser-friendly UMD build
+	{
+		input: 'npm.js',
+		output: {
+			exports: 'default, LatLonSpherical, LatLonEllipsoidal, LatLonVectors, Vector3d, Utm, Mgrs, OsGridRef, Dms',
+			name: 'geodesy',
+			file: 'dist/geodesy.js',
+			format: 'umd'
+		},
+		plugins: [
+			resolve(), // so Rollup can find `ms`
+			commonjs() // so Rollup can convert `ms` to an ES module
+		]
+	}
+];

--- a/utm.js
+++ b/utm.js
@@ -38,7 +38,7 @@ if (typeof module!='undefined' && module.exports) var LatLon = require('./latlon
  * @example
  *   var utmCoord = new Utm(31, 'N', 448251, 5411932);
  */
-function Utm(zone, hemisphere, easting, northing, datum, convergence, scale) {
+var Utm = function(zone, hemisphere, easting, northing, datum, convergence, scale) {
     if (!(this instanceof Utm)) { // allow instantiation without 'new'
         return new Utm(zone, hemisphere, easting, northing, datum, convergence, scale);
     }


### PR DESCRIPTION
Adds rollup configuration allowing the library to be built into a single distribution file and adds the ability to support multiple module types.

I needed to make a bundled version to use in a web app and thought it could be useful for others. i added a [rollup](https://rollupjs.org/guide/en) configuration and added rollup as  dev dependency.

To build a `umd` module:
```
npm install
npm run-script dist // will run "rollup -c" (rollup with config)
```
The result will be a new javascript file `dist/geodesy.js` that contains the geodesy library.

Others may update the `rollup.config.js` to change the output.

Note: I added a `.gitignore` and added `dist` directory to it, as to not change whats in the repo. Ideally the `dist` would exsist in the published npm package but not the repo.