### PR TITLE
Add "files" field to package.json to exclude test files from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,14 @@
       "strict": [ "error", "global" ]
     }
   },
+  "files": [ 
+    "dms.js",
+    "latlon-*.js",
+    "mgrs.js",
+    "osgridref.js",
+    "utm.js",
+    "vector3d.js"
+  ],
   "jsdoc": {
     "plugins": [ "plugins/markdown" ],
     "markdown": { "idInHeadings": true }


### PR DESCRIPTION
The test files (and the travis config) aren't needed when the package is installed
as an npm dependency, so they should be excluded from the published package.

See: https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package