### PR TITLE
add: index.js as "main" entrypoint In package.json.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+import Dms from './dms.js'
+import Utm from './utm.js'
+import Vector3d from './vector3d.js'
+import LatLonSpherical from './latlon-spherical.js'
+import Mgrs from './mgrs.js'
+import OsGridRef from './osgridref.js'
+import LatLon_NvectorEllipsoidal from './latlon-nvector-ellipsoidal.js'
+import LatLonNvectorSpherical from './latlon-nvector-spherical.js'
+import LatLonEllipsoidal_ReferenceFrame from './latlon-ellipsoidal-referenceframe.js'
+import LatLonEllipsoidal_Vincenty from './latlon-ellipsoidal-vincenty.js'
+import LatLonEllipsoidal from './latlon-ellipsoidal.js'
+import LatLonEllipsoidal_Datum from './latlon-ellipsoidal-datum.js'
+import LatLonEllipsoidal_ReferenceFrame_Params from './latlon-ellipsoidal-referenceframe-txparams.js'
+
+export { Dms, Utm, Vector3d, LatLonSpherical, Mgrs, OsGridRef, LatLon_NvectorEllipsoidal, LatLonNvectorSpherical, LatLonEllipsoidal_ReferenceFrame, LatLonEllipsoidal_Vincenty, LatLonEllipsoidal, LatLonEllipsoidal_Datum, LatLonEllipsoidal_ReferenceFrame_Params }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
+  "main": "index.js",
   "files": [ "dms.js", "latlon-*.js", "mgrs.js", "osgridref.js", "utm.js", "vector3d.js" ],
   "bugs": "https://github.com/chrisveness/geodesy/issues",
   "scripts": {


### PR DESCRIPTION
I recently ran into an issue with [Node-Red]() where I was unable to install your package through NPM automatically in a Function Node, because it lacked the standard ["main"](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#main) entrypoint in the `package.json` file. 

By doing so there are, of course, trade-offs, but I needed to do so to get it to work with my specific use case. The change in usage would only be in the way classes were imported into projects. 

Before:

```javascript
import LatLon, { Dms } from 'https://cdn.jsdelivr.net/npm/geodesy@2/latlon-ellipsoidal-vincenty.js'; // browser
import LatLon, { Dms } from 'geodesy/latlon-ellipsoidal-vincenty.js'; // Node.js
```

After:

```javascript
import LatLon, { Dms } from 'https://cdn.jsdelivr.net/npm/geodesy@2/latlon-ellipsoidal-vincenty.js';  //OR
import LatLonEllipsoidal_Vincenty, { Dms } from 'https://cdn.jsdelivr.net/npm/geodesy@2/index.js'; // browser
import LatLonEllipsoidal_Vincenty, { Dms } from 'geodesy';  //OR
import 'geodesy'; 

const point = new geodesy.LatLonEllipsoidal(1,1,0); // Node.js
```
